### PR TITLE
button to fake selection roof & fix bug search bar

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -10,9 +10,11 @@ import UiSearchBar from '@/components/ui/UiSearchBar.vue'
 import { viewList } from './model/views.model'
 import UiPopUpBottomInformation from '@/components/ui/UiPopUpBottomInformation.vue'
 import { usePanelsStore, PANEL_WIDTH } from '@/stores/panels'
+import { useRouter } from 'vue-router'
 
 const viewStore = useViewsStore()
 const panelStore = usePanelsStore()
+const router = useRouter()
 
 onBeforeMount(() => {
   const rennesApp = new RennesApp(mapConfig)
@@ -20,7 +22,7 @@ onBeforeMount(() => {
 })
 
 function isLeftPanelRetractable() {
-  const retractableList = [viewList['map-pcaet']]
+  const retractableList = [viewList['map-pcaet'], viewList['roof-selection']]
   return retractableList.includes(viewStore.currentView)
 }
 
@@ -31,6 +33,11 @@ const isDisplaySearchBar = computed(() => {
     viewList['roof-selected-information'],
   ].includes(viewStore.currentView)
 })
+
+function fakeNextStep() {
+  panelStore.isCompletelyHidden = false
+  router.push({ name: 'roof-selected-information' })
+}
 </script>
 
 <template>
@@ -66,6 +73,18 @@ const isDisplaySearchBar = computed(() => {
       :text="'Cliquez sur le pan de toit que vous souhaitez sélectionner.'"
       class="absolute z-20 bottom-5 left-[20%]"
     />
+    <button
+      class="absolute z-20 bottom-5 left-[10%] bg-white text-black"
+      @click="fakeNextStep()"
+      v-if="viewStore.currentView == viewList['roof-selection']"
+    >
+      Fake select roof button
+      <br />
+      <span class="text-sm font-light">
+        (While waiting the roof selection,<br />
+        click here to display the next step)
+      </span>
+    </button>
 
     <UiButtonWithTooltip
       v-if="isDisplaySearchBar"

--- a/src/assets/icons/search-empty.svg
+++ b/src/assets/icons/search-empty.svg
@@ -1,0 +1,12 @@
+<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_206_1091)">
+<path d="M7 13.5C10.5899 13.5 13.5 10.5899 13.5 7C13.5 3.41015 10.5899 0.5 7 0.5C3.41015 0.5 0.5 3.41015 0.5 7C0.5 10.5899 3.41015 13.5 7 13.5Z" stroke="#000001" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M2.39999 11.5999L11.6 2.3999" stroke="#000001" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M11.6 11.5999L2.39999 2.3999" stroke="#000001" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_206_1091">
+<rect width="14" height="14" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/components/home/SidePanel.vue
+++ b/src/components/home/SidePanel.vue
@@ -24,11 +24,14 @@ const leftAlignment = computed(() =>
 </script>
 
 <template>
-  <div class="flex shadow-sm min-h-screen">
+  <div
+    class="flex shadow-sm min-h-screen"
+    v-show="!panelStore.isCompletelyHidden"
+  >
     <div
       class="px-6 py-8 bg-white flex flex-col gap-8 max-h-screen overflow-y-auto scrollbar-hide"
       :class="`w-[${PANEL_WIDTH}]`"
-      v-if="panelStore.isInformationPanelShown"
+      v-show="panelStore.isInformationPanelShown"
     >
       <slot></slot>
     </div>

--- a/src/stores/panels.ts
+++ b/src/stores/panels.ts
@@ -9,6 +9,7 @@ export const PANEL_WIDTH = '450px' as const
 export const usePanelsStore = defineStore('panels', () => {
   const typePanelDisplay: Ref<typePanel> = ref('left')
   const isInformationPanelShown: Ref<boolean> = ref(true)
+  const isCompletelyHidden: Ref<boolean> = ref(false)
 
   function toggleInformationPanel() {
     isInformationPanelShown.value = !isInformationPanelShown.value
@@ -28,5 +29,6 @@ export const usePanelsStore = defineStore('panels', () => {
     typePanelDisplay,
     setTypePanelDisplay,
     isRightPanel,
+    isCompletelyHidden,
   }
 })

--- a/src/views/RoofSelectionView.vue
+++ b/src/views/RoofSelectionView.vue
@@ -1,16 +1,16 @@
 <script setup lang="ts">
 import { useViewsStore } from '@/stores/views'
-import { onBeforeMount } from 'vue'
+import { onMounted } from 'vue'
 import { viewList } from '@/model/views.model'
 import { usePanelsStore } from '@/stores/panels'
 
 const viewStore = useViewsStore()
 const panelsStore = usePanelsStore()
 
-onBeforeMount(async () => {
+onMounted(() => {
   viewStore.setCurrentView(viewList['roof-selection'])
   panelsStore.setTypePanelDisplay('left')
-  panelsStore.isInformationPanelShown = false
+  panelsStore.isCompletelyHidden = true
 })
 </script>
 


### PR DESCRIPTION
button to fake selection roof & fix bug search bar

### Description

Button to navigate from roof-selection page to roof-selected-information page
![image](https://user-images.githubusercontent.com/121813008/222398210-dea2e720-9bb5-4620-9c5b-12659261e49c.png)

Search Bar:
- Message when empty result 
- Disabled search button when empty result 
- Go to first address when user click on search button 
- Come back when user click on multiply button 
![image](https://user-images.githubusercontent.com/121813008/222398557-e7fee3f9-85df-47ec-9ed9-67d1b345263f.png)
