### PR TITLE
feat: keep grid when come back from next step, avoid recomputation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "@rushstack/eslint-patch": "^1.1.4",
         "@types/jest": "^29.4.0",
         "@types/jsdom": "^20.0.0",
-        "@types/node": "^16.11.56",
+        "@types/node": "^17.0.29",
         "@vitejs/plugin-vue": "^3.0.3",
         "@vitest/coverage-c8": "^0.23.2",
         "@vue/eslint-config-prettier": "^7.0.0",
@@ -3543,9 +3543,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.18.16",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.16.tgz",
-      "integrity": "sha512-ZOzvDRWp8dCVBmgnkIqYCArgdFOO9YzocZp8Ra25N/RStKiWvMOXHMz+GjSeVNe5TstaTmTWPucGJkDw0XXJWA=="
+      "version": "17.0.29",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.29.tgz",
+      "integrity": "sha512-tx5jMmMFwx7wBwq/V7OohKDVb/JwJU5qCVkeLMh1//xycAJ/ESuw9aJ9SEtlCZDYi2pBfe4JkisSoAtbOsBNAA=="
     },
     "node_modules/@types/prettier": {
       "version": "2.7.2",
@@ -17174,9 +17174,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.18.16",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.16.tgz",
-      "integrity": "sha512-ZOzvDRWp8dCVBmgnkIqYCArgdFOO9YzocZp8Ra25N/RStKiWvMOXHMz+GjSeVNe5TstaTmTWPucGJkDw0XXJWA=="
+      "version": "17.0.29",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.29.tgz",
+      "integrity": "sha512-tx5jMmMFwx7wBwq/V7OohKDVb/JwJU5qCVkeLMh1//xycAJ/ESuw9aJ9SEtlCZDYi2pBfe4JkisSoAtbOsBNAA=="
     },
     "@types/prettier": {
       "version": "2.7.2",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@rushstack/eslint-patch": "^1.1.4",
     "@types/jest": "^29.4.0",
     "@types/jsdom": "^20.0.0",
-    "@types/node": "^16.11.56",
+    "@types/node": "^17.0.29",
     "@vitejs/plugin-vue": "^3.0.3",
     "@vitest/coverage-c8": "^0.23.2",
     "@vue/eslint-config-prettier": "^7.0.0",
@@ -80,6 +80,7 @@
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.16",
     "prettier": "^2.7.1",
+    "resize-observer-polyfill": "1.5.1",
     "start-server-and-test": "^1.14.0",
     "tailwindcss": "^3.1.8",
     "ts-jest": "^29.0.5",
@@ -87,8 +88,7 @@
     "vite": "^3.0.9",
     "vitest": "^0.23.0",
     "vitest-canvas-mock": "^0.2.2",
-    "vue-tsc": "^0.40.7",
-    "resize-observer-polyfill": "1.5.1"
+    "vue-tsc": "^0.40.7"
   },
   "lint-staged": {
     "*.{js,ts,vue}": "eslint --cache",

--- a/src/components/map/MapComponent.vue
+++ b/src/components/map/MapComponent.vue
@@ -17,7 +17,6 @@ import {
   addRoofInteractionOn2dMap,
   bboxRoof,
   displayGridOnMap,
-  displayRoofShape,
   filterGrid,
   generateRectangleGrid,
   removeRoof2dShape,
@@ -35,7 +34,6 @@ import { solarPanelGridToSolarPanelModel } from '@/services/solarPanel'
 import { useRoofsStore } from '@/stores/roof'
 import { useMapStore } from '@/stores/map'
 import { useViewsStore } from '@/stores/views'
-import { getCenter } from 'ol/extent'
 import type { Grid } from '@/helpers/rectangleGrid'
 import { solarPanelPlacement } from '@/algorithm/solarPanelPlacement'
 import type { RoofSurfaceModel } from '@/model/roof.model'
@@ -96,24 +94,32 @@ async function setupGridInstallation() {
   if (addressStore.latitude !== 0 && addressStore.longitude !== 0) {
     await layerStore.enableLayer(RENNES_LAYER.roofSquaresArea)
     await layerStore.enableLayer(RENNES_LAYER.roofShape)
-    let roofShape = roofsStore.getFeaturesOfSelectedPanRoof()
-    displayRoofShape(rennesApp, roofShape)
-    let bboxOnRoof = bboxRoof(roofShape)
-    let grid: Grid = generateRectangleGrid(roofShape, bboxOnRoof)
-    let { grid: filterGeomGrid, matrix: gridMatrix } = filterGrid(
-      roofShape,
-      grid
+    // avoid recompute everything when came back from solar placement
+    if (!roofsStore.gridMatrix) {
+      let roofShape = roofsStore.getFeaturesOfSelectedPanRoof()
+      let bboxOnRoof = bboxRoof(roofShape)
+      let grid: Grid = generateRectangleGrid(roofShape, bboxOnRoof)
+      let { grid: filterGeomGrid, matrix: gridMatrix } = filterGrid(
+        roofShape,
+        grid
+      )
+      roofsStore.gridGeom = filterGeomGrid
+      roofsStore.gridMatrix = gridMatrix
+    } else {
+      roofsStore.restoreMatrixToClean()
+    }
+    displayGridOnMap(rennesApp, roofsStore.gridGeom!.featureCollection)
+    addRoofInteractionOn2dMap(
+      rennesApp,
+      roofsStore.getPreviouslySelected() ?? []
     )
-    roofsStore.gridMatrix = gridMatrix
-    displayGridOnMap(rennesApp, filterGeomGrid.featureCollection)
-    addRoofInteractionOn2dMap(rennesApp)
     rennesApp.getOpenlayerMap().getView().setZoom(22)
     rennesApp.getOpenlayerMap().getView().setMinZoom(21)
-    rennesApp.getOpenlayerMap().getView().setCenter(getCenter(bboxOnRoof))
   }
 }
 
 async function setupSolarPanelFixtures() {
+  roofsStore.saveCleanMatrix()
   substractSelectedSquaresFromGrid(roofsStore.gridMatrix!)
   const result = solarPanelPlacement(roofsStore.gridMatrix!)
   const selectedRoofModel: RoofSurfaceModel =
@@ -138,6 +144,12 @@ async function setupSolarPanelFixtures() {
 
 simulationStore.$subscribe(async () => {
   if (
+    simulationStore.currentStep === 1 &&
+    simulationStore.currentSubStep == 1
+  ) {
+    roofsStore.resetGridAndMatrix()
+  }
+  if (
     simulationStore.currentStep === 2 &&
     simulationStore.currentSubStep == 1
   ) {
@@ -156,7 +168,7 @@ simulationStore.$subscribe(async () => {
       simulationStore.currentStep === 3 &&
       simulationStore.currentSubStep == 1
     ) {
-      saveScreenShot(rennesApp)
+      await saveScreenShot(rennesApp)
     }
   }
 

--- a/src/interactions/olDragSquaresInteraction.ts
+++ b/src/interactions/olDragSquaresInteraction.ts
@@ -8,6 +8,8 @@ import { getUid, MapBrowserEvent } from 'ol'
 import type { Style } from 'ol/style'
 import type { StyleLike } from 'ol/style/Style'
 import { RENNES_LAYER } from '@/stores/layers'
+import type olFeature from 'ol/Feature'
+import type olGeometry from 'ol/geom/Geometry'
 
 export class OlDragSquaresInteraction extends PointerInteraction {
   initialCoordinate_: Coordinate | undefined
@@ -19,7 +21,11 @@ export class OlDragSquaresInteraction extends PointerInteraction {
   selectedStyle: Style
   isDragging: boolean
 
-  constructor(gridFeaturesLayer: VectorLayer<VectorSource>, style: Style) {
+  constructor(
+    gridFeaturesLayer: VectorLayer<VectorSource>,
+    previouslySelected: olFeature<olGeometry>[],
+    style: Style
+  ) {
     super()
     this.initialCoordinate_ = undefined
     this.feature_ = undefined
@@ -29,6 +35,17 @@ export class OlDragSquaresInteraction extends PointerInteraction {
     this.originalFeatureStyles = new Map<string, StyleLike>()
     this.selectedStyle = style
     this.isDragging = false
+    previouslySelected.forEach((feature) => {
+      gridFeaturesLayer
+        .getSource()
+        ?.getFeatures()
+        .forEach((f) => {
+          if (feature.getProperty('center') === f.getProperty('center')) {
+            this.persistingSelectedMap.set(getUid(f), f)
+            this.applySelectedStyle_(f)
+          }
+        })
+    })
   }
 
   handleDownEvent(evt: MapBrowserEvent<UIEvent>) {


### PR DESCRIPTION
### JIRA issue

https://jira.camptocamp.com/browse/GSREN3D-XXX

### Description

* avoid to recompute grid when came back from next steps
* keep the squares of the interaction available when came back from next steps
* do not display roof layer anymore


### Screenshots

https://github.com/sigrennesmetropole/cooperation_jn_solar/assets/91056006/0bc8a71d-52ed-4376-91d4-0f2a1416435c


