### PR TITLE
GSREN3D-443: Use 3D tiles from our own S3 bucket.

### DIFF
--- a/src/map.config.json
+++ b/src/map.config.json
@@ -59,7 +59,7 @@
     {
       "type": "CesiumTilesetLayer",
       "name": "roof3d",
-      "url": "https://demo.virtualcitymap.de/rennes/datasource-data/fe157549-1c80-47f1-828a-f1a97bf92d80/",
+      "url": "https://rennes-coopterr-solaire-tiles.s3.fr-par.scw.cloud/fe157549-1c80-47f1-828a-f1a97bf92d80",
       "activeOnStartup": true,
       "allowPicking": true,
       "screenSpaceError": 16,


### PR DESCRIPTION
<!-- Title must be: GSREN3D-XXX: Description of changes -->

### JIRA issue

https://jira.camptocamp.com/browse/GSREN3D-443

### Description

- Use 3D tiles from our own S3 bucket.
- Tested locally
- Reported the previous issue to Leo, and fixed
- If you want to review it, please test it locally also :)

### Screenshots

(only if the final render is different)
